### PR TITLE
Fix problem in DatacenterFromVMInventoryPath function when datacenter is in a folder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -262,7 +262,7 @@ BUG FIXES:
 
 FEATURES:
 * `data/dynamic`: Data source which can be used to match any tagged managed object. ([#1103](https://github.com/hashicorp/terraform-provider-vsphere/pull/1103))
-* `resource/vm_storage_policy_profile`: A resource for tag based storage placement.
+* `resource/vm_storage_policy_`: A resource for tag based storage placement.
   policies management. ([#1094](https://github.com/hashicorp/terraform-provider-vsphere/pull/1094))
 * `resource/virtual_machine`: Add support for PCI passthrough devices on virtual
   machines. ([#1099](https://github.com/hashicorp/terraform-provider-vsphere/pull/1099))
@@ -367,7 +367,7 @@ FEATURES:
 
 IMPROVEMENTS:
 * Switch to govmomi REST client ([#955](https://github.com/hashicorp/terraform-provider-vsphere/pull/955))
-* Add storage policy to `virtual_machine` resource. ** Requires `profile-driven
+* Add storage policy to `virtual_machine` resource. ** Requires `profile-driven 
   storage` privilege on vCenter Server for the Terraform provider user. ([#881](https://github.com/hashicorp/terraform-provider-vsphere/pull/881))
 
 ## 1.15.0 (January 23, 2020)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -367,7 +367,7 @@ FEATURES:
 
 IMPROVEMENTS:
 * Switch to govmomi REST client ([#955](https://github.com/hashicorp/terraform-provider-vsphere/pull/955))
-* Add storage policy to `virtual_machine` resource. ** Requires `profile-driven 
+* Add storage policy to `virtual_machine` resource. ** Requires `profile-driven
   storage` privilege on vCenter Server for the Terraform provider user. ([#881](https://github.com/hashicorp/terraform-provider-vsphere/pull/881))
 
 ## 1.15.0 (January 23, 2020)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -262,7 +262,7 @@ BUG FIXES:
 
 FEATURES:
 * `data/dynamic`: Data source which can be used to match any tagged managed object. ([#1103](https://github.com/hashicorp/terraform-provider-vsphere/pull/1103))
-* `resource/vm_storage_policy_`: A resource for tag based storage placement.
+* `resource/vm_storage_policy_profile`: A resource for tag based storage placement.
   policies management. ([#1094](https://github.com/hashicorp/terraform-provider-vsphere/pull/1094))
 * `resource/virtual_machine`: Add support for PCI passthrough devices on virtual
   machines. ([#1099](https://github.com/hashicorp/terraform-provider-vsphere/pull/1099))

--- a/vsphere/internal/helper/datacenter/datacenter_helper.go
+++ b/vsphere/internal/helper/datacenter/datacenter_helper.go
@@ -44,7 +44,6 @@ func FromInventoryPath(client *govmomi.Client, inventoryPath string) (*object.Da
 // VM inventory paths look like this: /SomeFolder/DatacenterName/.../VMName (datacenter is in a folder) or
 // /DatacenterName/.../VMName (datacenter is not in a folder).
 // We had a bug where the datacenter was in a folder and instead of the datacenter, the folder was returned.
-// See https://dev.azure.com/msazuredev/AzureForOperators/_workitems/edit/748713
 // The fixed function takes the inventory path and splits it by / as the delimiter. It then takes each part
 // of the inventory path in turn and tries to get the datacenter of the given name.
 // If it doesn't work, the current part is probably a folder and not a datacenter, so it tries again

--- a/vsphere/internal/helper/datacenter/datacenter_helper.go
+++ b/vsphere/internal/helper/datacenter/datacenter_helper.go
@@ -5,6 +5,9 @@ package datacenter
 
 import (
 	"context"
+	"fmt"
+	"log"
+	"strings"
 
 	"github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/folder"
 	"github.com/hashicorp/terraform-provider-vsphere/vsphere/internal/helper/provider"
@@ -36,16 +39,36 @@ func FromInventoryPath(client *govmomi.Client, inventoryPath string) (*object.Da
 	return dc, nil
 }
 
-// DatacenterFromVMInventoryPath returns the Datacenter object which is part of a given VM InventoryPath
+// DatacenterFromVMInventoryPath returns the Datacenter object which is part of a given VM InventoryPath.
+// This is also deals with the case where the datacenter is in a folder.
+// VM inventory paths look like this: /SomeFolder/DatacenterName/.../VMName (datacenter is in a folder) or
+// /DatacenterName/.../VMName (datacenter is not in a folder).
+// We had a bug where the datacenter was in a folder and instead of the datacenter, the folder was returned.
+// See https://dev.azure.com/msazuredev/AzureForOperators/_workitems/edit/748713
+// The fixed function takes the inventory path and splits it by / as the delimiter. It then takes each part
+// of the inventory path in turn and tries to get the datacenter of the given name.
+// If it doesn't work, the current part is probably a folder and not a datacenter, so it tries again
+// with the next part of the inventory path until it gets the datacenter.
+// Note that it only tries to find the datacenter on the given VM inventory path, and NOT on other paths.
+// So, datacenters with the same name as another folder should not be a problem.
+// If the datacenter is not found at all on the given inventory path, it returns an error.
 func DatacenterFromVMInventoryPath(client *govmomi.Client, inventoryPath string) (*object.Datacenter, error) {
-	dcPath, err := folder.RootPathParticleDatastore.SplitDatacenterFromVMInventoryPath(inventoryPath)
-	if err != nil {
-		return nil, err
-	}
-	dc, err := FromPath(client, dcPath)
-	if err != nil {
-		return nil, err
-	}
+	// Split the VM inventory path by /.
+	inventoryPathSplit := strings.Split(inventoryPath, "/")
 
-	return dc, nil
+	// The datacenter name is in the inventory path.
+	// Iterate through the inventory path until we find the datacenter name.
+	for _, dcAttempt := range inventoryPathSplit {
+		dc, err := FromPath(client, dcAttempt)
+		if err != nil {
+			// Datacenter with the given name not found, it is probably a folder, so try again with the next part of the inventory path.
+			log.Printf("[DEBUG] Could not find datacenter '%s' on inventory path %s, trying again", dcAttempt, inventoryPath)
+		} else {
+			// We got the datacenter, return it.
+			log.Printf("[DEBUG] Found datacenter %s on inventory path %s", dcAttempt, inventoryPath)
+			return dc, nil
+		}
+	}
+	// If we still don't have the datacenter, return an error.
+	return nil, fmt.Errorf("Could not find datacenter on inventory path %s", inventoryPath)
 }

--- a/vsphere/internal/helper/datacenter/datacenter_helper.go
+++ b/vsphere/internal/helper/datacenter/datacenter_helper.go
@@ -40,11 +40,10 @@ func FromInventoryPath(client *govmomi.Client, inventoryPath string) (*object.Da
 }
 
 // DatacenterFromVMInventoryPath returns the Datacenter object which is part of a given VM InventoryPath.
-// This is also deals with the case where the datacenter is in a folder.
+// This also deals with the case where the datacenter is in a folder.
 // VM inventory paths look like this: /SomeFolder/DatacenterName/.../VMName (datacenter is in a folder) or
 // /DatacenterName/.../VMName (datacenter is not in a folder).
-// We had a bug where the datacenter was in a folder and instead of the datacenter, the folder was returned.
-// The fixed function takes the inventory path and splits it by / as the delimiter. It then takes each part
+// The function takes the inventory path and splits it by / as the delimiter. It then takes each part
 // of the inventory path in turn and tries to get the datacenter of the given name.
 // If it doesn't work, the current part is probably a folder and not a datacenter, so it tries again
 // with the next part of the inventory path until it gets the datacenter.

--- a/vsphere/internal/helper/folder/folder_helper.go
+++ b/vsphere/internal/helper/folder/folder_helper.go
@@ -76,16 +76,6 @@ func (p RootPathParticle) SplitDatacenter(inventoryPath string) (string, error) 
 	return s[0], nil
 }
 
-// SplitDatacenterFromVMInventoryPath is a convenience method that splits out the datacenter path
-// from the supplied VM inventory path for the particle.
-func (p RootPathParticle) SplitDatacenterFromVMInventoryPath(inventoryPath string) (string, error) {
-	s := strings.SplitN(inventoryPath, "/", 3)
-	if len(s) != 3 {
-		return inventoryPath, fmt.Errorf("could not split path %q on %q", inventoryPath, p.Delimiter())
-	}
-	return s[1], nil
-}
-
 // SplitRelative is a convenience method that splits out the relative path from
 // the supplied path for the particle.
 func (p RootPathParticle) SplitRelative(inventoryPath string) (string, error) {


### PR DESCRIPTION
### Description

<!--- Please leave a helpful description of the pull request here. --->

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch?

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vsphere/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
...
```
### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
